### PR TITLE
Increase height of Armory background animation

### DIFF
--- a/App/Containers/LocationScreen.js
+++ b/App/Containers/LocationScreen.js
@@ -11,7 +11,7 @@ import {
 import PurpleGradient from '../Components/PurpleGradient'
 import VenueMap from '../Components/VenueMap'
 import Gallery from '../Components/Gallery'
-import { Images } from '../Themes'
+import { Images, Metrics } from '../Themes'
 import { connect } from 'react-redux'
 import Secrets from 'react-native-config'
 import styles from './Styles/LocationScreenStyle'
@@ -93,7 +93,7 @@ class LocationScreen extends React.Component {
   }
 
   renderBackground = () => {
-    const height = 314
+    const height = Metrics.locationBackgroundHeight
     const { scrollY } = this.state
     return (
       <Animated.Image

--- a/App/Themes/Metrics.js
+++ b/App/Themes/Metrics.js
@@ -18,6 +18,7 @@ const metrics = {
   navBarHeight: (Platform.OS === 'ios') ? 64 : 54,
   buttonRadius: 4,
   cardRadius: 5,
+  locationBackgroundHeight: 324,
   icons: {
     tiny: 15,
     small: 20,


### PR DESCRIPTION
Trello: https://trello.com/c/yqB5ELIB/6-fix-space-between-armory-and-map

Increases the height of the armory background animation. Also moved the value to Metrics, but I'm willing to undo that bit if people have feelings about it. 

<img width="466" alt="screen shot 2017-05-23 at 3 02 26 pm" src="https://cloud.githubusercontent.com/assets/6894653/26378585/016e377a-3fca-11e7-884f-3ba66d8af5bd.png">
<img width="346" alt="screen shot 2017-05-23 at 3 02 59 pm" src="https://cloud.githubusercontent.com/assets/6894653/26378587/03409fde-3fca-11e7-90a4-d7ba8105b039.png">

