### PR TITLE
Android styles

### DIFF
--- a/App/Components/BackgroundVideo.js
+++ b/App/Components/BackgroundVideo.js
@@ -1,17 +1,22 @@
 import React, { Component } from 'react'
+import { View } from 'react-native'
 import Video from 'react-native-video'
 
 export default class BackgroundVideo extends Component {
   render () {
-    return (
-      <Video
-        source={this.props.source}
-        paused={!this.props.isActive}
-        resizeMode='cover'
-        style={this.props.style}
-        muted
-        repeat
-      />
-    )
+    if (this.props.isActive) {
+      return (
+        <Video
+          source={this.props.source}
+          paused={!this.props.isActive}
+          resizeMode='cover'
+          style={this.props.style}
+          muted
+          repeat
+        />
+      )
+    } else {
+      return (<View />)
+    }
   }
 }

--- a/App/Components/Break.js
+++ b/App/Components/Break.js
@@ -26,9 +26,7 @@ export default class Break extends React.Component {
   renderContent () {
     const {
       type,
-      start,
       duration,
-      currentTime,
       isCurrentDay,
       isActive
     } = this.props
@@ -64,14 +62,11 @@ export default class Break extends React.Component {
             </View>
           </View>
         </View>
-        {isActive &&
-          <TimeIndicator start={start} duration={duration} time={currentTime} />
-        }
       </View>
     )
   }
 
-  render () {
+  renderWrapper () {
     if (this.props.onPress) {
       return (
         <TouchableOpacity onPress={this.props.onPress}>
@@ -81,6 +76,17 @@ export default class Break extends React.Component {
     } else {
       return this.renderContent()
     }
+  }
+
+  render () {
+    const { currentTime, duration, start, isActive } = this.props
+
+    return (
+      <View>
+        {this.renderWrapper()}
+        {isActive && <TimeIndicator start={start} duration={duration} time={currentTime} />}
+      </View>
+    )
   }
 }
 

--- a/App/Components/Break.js
+++ b/App/Components/Break.js
@@ -1,11 +1,28 @@
-import React, { PropTypes, Component } from 'react'
+import React, { PropTypes } from 'react'
 import { View, Text, Image, TouchableOpacity } from 'react-native'
 import { Images, Videos } from '../Themes'
 import TimeIndicator from './TimeIndicator'
 import BackgroundVideo from './BackgroundVideo'
 import styles from './Styles/BreakStyle'
 
-export default class Break extends Component {
+export default class Break extends React.Component {
+
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      imageWidth: 335
+    }
+  }
+
+  onLayout = (event) => {
+    const width = event.nativeEvent.layout.width
+
+    this.setState({
+      imageWidth: width
+    })
+  }
+
   renderContent () {
     const {
       type,
@@ -25,10 +42,12 @@ export default class Break extends Component {
     const background = type === 'lunch' ? Images.lunchBreak : Images.coffeeBreak
     const video = type === 'lunch' ? Videos.lunch : Videos.coffee
 
+    const imageWidth = this.state.imageWidth
+
     return (
       <View>
-        <View style={containerStyles}>
-          <Image source={background} style={styles.background} />
+        <View style={containerStyles} onLayout={this.onLayout}>
+          <Image source={background} style={[styles.background, {width: imageWidth}]} />
           <BackgroundVideo source={video} style={styles.video} isActive={isActive} />
           <View style={styles.contentContainer}>
             <View style={styles.content}>

--- a/App/Components/Styles/BreakStyle.js
+++ b/App/Components/Styles/BreakStyle.js
@@ -5,7 +5,9 @@ export default StyleSheet.create({
   container: {
     flex: 1,
     marginVertical: Metrics.baseMargin,
-    marginHorizontal: Metrics.doubleBaseMargin
+    marginHorizontal: Metrics.doubleBaseMargin,
+    backgroundColor: Colors.transparent,
+    height: 125
   },
   currentDay: {
     marginLeft: 16,
@@ -25,7 +27,10 @@ export default StyleSheet.create({
   },
   background: {
     flex: 1,
-    resizeMode: 'cover'
+    resizeMode: 'cover',
+    borderRadius: 5,
+    borderWidth: 1,
+    borderColor: Colors.snow
   },
   video: {
     position: 'absolute',

--- a/App/Components/Talk.js
+++ b/App/Components/Talk.js
@@ -42,26 +42,28 @@ export default class Talk extends React.Component {
     ]
 
     return (
-      <TouchableOpacity onPress={this.props.onPress}>
-        <View style={containerStyles}>
-          <View style={styles.info}>
-            <View style={styles.infoText}>
-              <Text style={styles.name}>{name}</Text>
-              <Text style={styles.title}>{title}</Text>
+      <View>
+        <TouchableOpacity onPress={this.props.onPress}>
+          <View style={containerStyles}>
+            <View style={styles.info}>
+              <View style={styles.infoText}>
+                <Text style={styles.name}>{name}</Text>
+                <Text style={styles.title}>{title}</Text>
+              </View>
+              <Image style={styles.avatar} source={{uri: avatarURL}} />
             </View>
-            <Image style={styles.avatar} source={{uri: avatarURL}} />
+            <TalkInfo
+              start={start}
+              duration={duration}
+              remindMe={sendReminder}
+              toggleRemindMe={() => this.toggleReminder()}
+            />
           </View>
-          <TalkInfo
-            start={start}
-            duration={duration}
-            remindMe={sendReminder}
-            toggleRemindMe={() => this.toggleReminder()}
-          />
-        </View>
+        </TouchableOpacity>
         {isActive &&
           <TimeIndicator start={start} duration={duration} time={currentTime} />
         }
-      </TouchableOpacity>
+      </View>
     )
   }
 

--- a/App/Containers/Styles/TalkDetailScreenStyle.js
+++ b/App/Containers/Styles/TalkDetailScreenStyle.js
@@ -50,13 +50,14 @@ export default StyleSheet.create({
   },
   avatar: {
     position: 'absolute',
-    top: -53,
+    top: -43,
     left: (Metrics.screenWidth - (Metrics.doubleBaseMargin * 2)) / 2 - 53,
     height: 106,
     width: 106,
     borderRadius: 53,
     borderColor: Colors.snow,
-    borderWidth: 1
+    borderWidth: 1,
+    zIndex: 4
   },
   sectionHeading: {
     alignSelf: 'flex-start',

--- a/App/Containers/Styles/TalksScreenStyle.js
+++ b/App/Containers/Styles/TalksScreenStyle.js
@@ -39,7 +39,8 @@ export default StyleSheet.create({
     shadowRadius: 20,
     shadowColor: 'black',
     shadowOpacity: 0.8,
-    zIndex: 1
+    elevation: 20,
+    backgroundColor: 'black'
   },
   dayToggle: {
     flexDirection: 'row',

--- a/App/Containers/TalkDetailScreen.js
+++ b/App/Containers/TalkDetailScreen.js
@@ -33,11 +33,11 @@ class TalkDetail extends React.Component {
             </TouchableOpacity>
             <View style={styles.cardShadow1} />
             <View style={styles.cardShadow2} />
+            <Image
+              style={styles.avatar}
+              source={{uri: `https://infinite.red/images/chainreact/${this.props.image}.png`}}
+            />
             <View style={styles.card}>
-              <Image
-                style={styles.avatar}
-                source={{uri: `https://infinite.red/images/chainreact/${this.props.image}.png`}}
-              />
               <Text style={styles.sectionHeading}>
                 TALK
               </Text>


### PR DESCRIPTION
Trello: 
https://trello.com/c/D6D6vnoX/9-android-schedule-doesn-t-render-after-switching-days
https://trello.com/c/TPLbYoO0/10-android-speaker-avatar-is-cut-off-on-talk-detail-screen
https://trello.com/c/Mmls4yPa/13-android-sun-icon-cut-off-near-the-end-of-talks
https://trello.com/c/Ux7f0i9g/11-android-break-lunch-videos-always-playing

Fixes for a handful of miscellaneous Android style bugs

<img width="362" alt="avatar_bug" src="https://cloud.githubusercontent.com/assets/6894653/26472649/ef51b9b6-415b-11e7-9d21-3f798da7631d.png">
<img width="325" alt="avatar_fixed" src="https://cloud.githubusercontent.com/assets/6894653/26472648/ef51339c-415b-11e7-9bce-7da6533ba694.png">
<img width="404" alt="sun_bug" src="https://cloud.githubusercontent.com/assets/6894653/26472647/ef4f480c-415b-11e7-9af6-f141ff0f0ab8.png">
<img width="410" alt="sun_fixed" src="https://cloud.githubusercontent.com/assets/6894653/26472644/ef3dac0a-415b-11e7-95e9-ad0fed81cc7f.png">
<img width="346" alt="tuesday_bug" src="https://cloud.githubusercontent.com/assets/6894653/26472646/ef40444c-415b-11e7-8b1a-78d00d336a12.png">
<img width="332" alt="tuesday_fixed" src="https://cloud.githubusercontent.com/assets/6894653/26472645/ef3e598e-415b-11e7-980f-632b7e4f7064.png">
![video_bug](https://cloud.githubusercontent.com/assets/6894653/26472673/0e7be65e-415c-11e7-9271-83fc6928539f.png)
![video_fixed](https://cloud.githubusercontent.com/assets/6894653/26472672/0e79b3d4-415c-11e7-842f-24f2716e3266.png)

