### PR TITLE
Allow day selection while scrolling

### DIFF
--- a/App/Containers/ScheduleScreen.js
+++ b/App/Containers/ScheduleScreen.js
@@ -153,13 +153,13 @@ class ScheduleScreen extends React.Component {
         colors={['#46114E', '#521655', '#571757']}
         style={styles.headerGradient}>
         <View style={styles.dayToggle}>
-          <TouchableOpacity onPress={() => this.setActiveDay(0)}>
+          <TouchableOpacity onPressIn={() => this.setActiveDay(0)}>
             <Text
               style={activeDay === 0 ? styles.activeDay : styles.inactiveDay}>
               Monday July, 17th
             </Text>
           </TouchableOpacity>
-          <TouchableOpacity onPress={() => this.setActiveDay(1)}>
+          <TouchableOpacity onPressIn={() => this.setActiveDay(1)}>
             <Text
               style={activeDay === 1 ? styles.activeDay : styles.inactiveDay}>
               Tuesday July, 18th


### PR DESCRIPTION
Trello: https://trello.com/c/drVI5f8i/12-can-t-switch-days-while-content-is-still-scrolling

According to https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html#props, 
`onPress` can be cancelled by a scroll that steals the responder lock. But in this case, it doesn't really make sense to prevent you from switching days while scrolling, so `onPressIn` triggers regardless of scrolling activity.