### PR TITLE
Scroll to top on tab change or press of current tab for better UX

### DIFF
--- a/App/Containers/ScheduleScreen.js
+++ b/App/Containers/ScheduleScreen.js
@@ -141,6 +141,8 @@ class ScheduleScreen extends React.Component {
       activeDay: day,
       isCurrentDay: isCurrentDay(currentTime, day)
     }))
+    // Scroll to top on tab change or press of current tab
+    this.refs.listView.scrollTo({y: 0, animated: false})
   }
 
   renderDayToggle () {
@@ -176,6 +178,7 @@ class ScheduleScreen extends React.Component {
         {this.renderDayToggle()}
         {this.state.isCurrentDay && <View style={styles.timeline} />}
         <ListView
+          ref='listView'
           contentContainerStyle={styles.listContent}
           dataSource={this.state.dataSource}
           onLayout={this.onLayout}


### PR DESCRIPTION
### The issue:
When changing tab after scroll, selected tab's scrollview's `y` position is that of the first screen
![crapp - no scroll on tab change](https://cloud.githubusercontent.com/assets/10098988/26531832/a1fced30-43b7-11e7-86db-30cac3625bef.gif)

 ### The fix:
Let's scroll to top on tab change and on repeat press of the current tab
![crapp - do scroll on tab change](https://cloud.githubusercontent.com/assets/10098988/26531850/f467263a-43b7-11e7-9098-37f0e46ae938.gif)
