### PR TITLE
Allow for multiple speakers

### DIFF
--- a/App/Containers/ScheduleScreen.js
+++ b/App/Containers/ScheduleScreen.js
@@ -86,14 +86,14 @@ class ScheduleScreen extends React.Component {
     if (rowData.type === 'talk') {
       return (
         <Talk
-          name={rowData.name}
+          name={rowData.speaker}
           avatarURL={`https://infinite.red/images/chainreact/${rowData.image}.png`}
           title={rowData.title}
           start={eventStart}
           duration={eventDuration}
           onPress={() => this.onEventPress(rowData)}
-          onPressTwitter={() => this.props.onPressTwitter(rowData.twitter)}
-          onPressGithub={() => this.props.onPressGithub(rowData.github)}
+          onPressTwitter={() => this.props.onPressTwitter(rowData.speakerInfo[0].twitter)}
+          onPressGithub={() => this.props.onPressGithub(rowData.speakerInfo[0].github)}
           currentTime={currentTime}
           isCurrentDay={isCurrentDay}
           isActive={isActive}

--- a/App/Containers/TalkDetailScreen.js
+++ b/App/Containers/TalkDetailScreen.js
@@ -24,6 +24,37 @@ class TalkDetail extends React.Component {
     this.props.navigation.dispatch(NavigationActions.back())
   }
 
+  renderSpeaker = (speaker, index) => {
+    return (
+      <View key={index}>
+        <Text style={styles.heading}>
+          {speaker.name}
+        </Text>
+        <Text style={styles.description}>
+          {speaker.bio}
+        </Text>
+        <View style={styles.social}>
+          <SocialMediaButton
+            network='twitter'
+            spacing='right'
+            onPress={() => this.props.onPressTwitter(speaker.twitter)}
+          />
+          <SocialMediaButton
+            network='github'
+            spacing='right'
+            onPress={() => this.props.onPressGithub(speaker.github)}
+          />
+        </View>
+      </View>
+    )
+  }
+
+  renderSpeakers = () => {
+    const { speakerInfo } = this.props
+
+    return (speakerInfo.map((speaker, index) => this.renderSpeaker(speaker, index)))
+  }
+
   render () {
     return (
       <PurpleGradient style={styles.linearGradient}>
@@ -52,24 +83,7 @@ class TalkDetail extends React.Component {
               <Text style={styles.sectionHeading}>
                 ABOUT
               </Text>
-              <Text style={styles.heading}>
-                {this.props.name}
-              </Text>
-              <Text style={styles.description}>
-                {this.props.bio}
-              </Text>
-              <View style={styles.social}>
-                <SocialMediaButton
-                  network='twitter'
-                  spacing='right'
-                  onPress={() => this.props.onPressTwitter(this.props.twitter)}
-                />
-                <SocialMediaButton
-                  network='github'
-                  spacing='right'
-                  onPress={() => this.props.onPressGithub(this.props.github)}
-                />
-              </View>
+              {this.renderSpeakers()}
             </View>
             <TalkInfo
               start={new Date(this.props.eventStart)}

--- a/App/Fixtures/schedule.json
+++ b/App/Fixtures/schedule.json
@@ -2,243 +2,403 @@
   "schedule": [
     {
       "type":"talk",
-      "name":"Mike Grabowski",
+      "speaker":"Mike Grabowski",
       "image":"mike",
-      "twitter":"grabbou",
-      "company":"Callstack",
-      "bio":"Mike is the founder of Callstack.io, a React Native core contributor, and the creator of numerous open source libraries.",
       "title":"No Title",
       "description":"",
       "time":"7/17/2017 9:00 AM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Mike Grabowski",
+          "bio":"Mike is the founder of Callstack.io, a React Native core contributor, and the creator of numerous open source libraries.",
+          "twitter":"grabbou",
+          "github": "grabbou",
+          "company":"Callstack"
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Brent Vatne",
+      "speaker":"Brent Vatne",
       "image":"brent",
-      "twitter":"notbrent",
-      "company":"Exponent",
-      "bio":"Front-end web/mobile developer working on Expo (https://expo.io) and React Native",
       "title":"React Native Sand Paper",
       "description":"I'll talk about three tools aimed at reducing friction to building and sharing React Native apps:\n\n1) create-react-native-app\n2) Exponent home\n3) Sketch (successor to React Native Playground)",
       "time":"7/17/2017 9:30 AM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Brent Vatne",
+          "twitter":"notbrent",
+          "github": "brentvatne",
+          "company":"Expo",
+          "bio":"Front-end web/mobile developer working on Expo (https://expo.io) and React Native"
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Richard Threlkeld",
+      "speaker":"Richard Threlkeld",
       "image":"richard",
-      "twitter":"undef_obj",
-      "company":"Amazon",
-      "bio":"Senior Technical Product Manager at AWS, focusing on developer experience in AWS Mobile.",
       "title":"Realtime Event Processing, Streaming and Subscription for React Native Using Cloud Services",
       "description":"",
       "time":"7/17/2017 10:30 AM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Richard Threlkeld",
+          "twitter":"undef_obj",
+          "github": "RTHRELKELD1980",
+          "company":"Amazon",
+          "bio":"Senior Technical Product Manager at AWS, focusing on developer experience in AWS Mobile."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Poornima Venkat",
+      "speaker":"Poornima Venkat",
       "image":"poornima",
-      "twitter":"poorni_venkat",
-      "company":"PayPal",
-      "bio":"Poornima is a web developer and was instrumental in development and adoption of one of the most successful open source projects at Paypal: Krakenjs – A web application framework on node.js. She is also a key proponent of bringing open source mentality within Paypal to break silo'ed development and enable more collaboration across teams. She has been evangelizing OSS work and talking about the revolution in engineering culture across various products at Paypal.",
       "title":"Experimenting with a Paypal Checkout SDK using React Native",
       "description":"This talk is a technical deep-dive of how we use react-native as a means to deliver Checkout experience in our open sourced Paypal SDK. It will also layout how react-native has given us the power to steer without merchants having to reintegrate and republish with every incremental SDK release.",
       "time":"7/17/2017 11:00 AM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name":"Poornima Venkat",
+          "twitter":"poorni_venkat",
+          "github": "pvenkatakrishnan",
+          "company":"PayPal",
+          "bio":"Poornima is a web developer and was instrumental in development and adoption of one of the most successful open source projects at Paypal: Krakenjs – A web application framework on node.js. She is also a key proponent of bringing open source mentality within Paypal to break silo'ed development and enable more collaboration across teams. She has been evangelizing OSS work and talking about the revolution in engineering culture across various products at Paypal."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Ben Ilegbodu",
+      "speaker":"Ben Ilegbodu",
       "image":"ben",
-      "twitter":"benmvp",
-      "company":"Eventbrite",
-      "bio":"Ben is a Christian, a husband and a father of 2 with 10+ years of experience developing user interfaces for the Web. He currently leads and manages Eventbrite’s Frontend Platform team. On the side, Ben also enjoys playing basketball, DIY, watching movies, and blogging (benmvp.com) / tweeting (@benmvp) about his experiences with new web technologies.",
+
       "title":"React Native + ES.next = ♥︎",
       "description":"Discover how to leverage the new JavaScript language features and apply them to our React Native project.",
       "time":"7/17/2017 11:30 AM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name":"Ben Ilegbodu",
+          "twitter":"benmvp",
+          "github": "benmvp",
+          "company":"Eventbrite",
+          "bio":"Ben is a Christian, a husband and a father of 2 with 10+ years of experience developing user interfaces for the Web. He currently leads and manages Eventbrite’s Frontend Platform team. On the side, Ben also enjoys playing basketball, DIY, watching movies, and blogging (benmvp.com) / tweeting (@benmvp) about his experiences with new web technologies."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Nader Dabit",
+      "speaker":"Nader Dabit",
       "image":"nader",
-      "twitter":"dabit3",
-      "company":"React Native Training",
-      "bio":"Nader is a Software Developer by trade, the author of React Native in Action by Manning Publications, the creator of React Native Elements, and the host of React Native Radio on Devchat.tv.",
       "title":"How to Sanely Work with File Types in a Cross Platform React Native Application",
       "description":"Working consistently across multiple platforms with different file types in React Native can be challenging. In this talk, I will discuss and implement working with and opening a multitude of different file types consistently on both iOS and Android.",
       "time":"7/17/2017 1:30 PM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name":"Nader Dabit",
+          "twitter":"dabit3",
+          "github": "dabit3",
+          "company":"React Native Training",
+          "bio":"Nader is a Software Developer by trade, the author of React Native in Action by Manning Publications, the creator of React Native Elements, and the host of React Native Radio on Devchat.tv."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Naoufal Kadhom",
+      "speaker":"Naoufal Kadhom",
       "image":"naoufal",
-      "twitter":"naoufal",
-      "company":"Netflix",
-      "bio":"Naoufal is a Web Developer & Designer currently based in Montreal. He makes responsive stuff with HTML5, CSS3 and Javascript -- and loves designing Sketch. His name is pronounced \"Nofell\".",
       "title":"Accepting Mobile Payments with React Native",
       "description":"In this talk, we’ll dive into the mobile payments landscape and explore the various ways that we can accept payments in our React Native applications.  We’ll then focus in on mobile wallets and see how we can leverage them to eliminate the payment form and reduce friction in our checkouts.  Finally, we’ll learn how we can do all this while sharing our payment code across platforms.",
       "time":"7/17/2017 2:00 PM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Naoufal Kadhom",
+          "twitter":"naoufal",
+          "github": "naoufal",
+          "company":"Netflix",
+          "bio":"Naoufal is a Web Developer & Designer currently based in Montreal. He makes responsive stuff with HTML5, CSS3 and Javascript -- and loves designing Sketch. His speaker is pronounced \"Nofell\"."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Kyle Poole & Thomas Bruketta",
+      "speaker":"Kyle Poole & Thomas Bruketta",
       "image":"kyle_thomas",
-      "twitter": ["kylpo", "SirTeebs"],
-      "company":"Instrument",
-      "bio":"Kyle Poole and Thomas Bruketta will co-present this talk. This dynamic duo has been crafting React Native applications at Instrument (here in Portland) over the last year for global clients. Both developers are contributors to the React Native open source community and Kyle Poole has created a collection of React Native primitives called Constelation that are a part of our team’s daily workflow ",
       "title":"Gestures here. Gestures there. Gestures everywhere!",
       "description":"This talk digs into building rich touch interactions with React Native. There’s a deeper level than Touchable* components and PanResponders. Kyle and Thomas will uncover it, and show off its full potential!",
       "time":"7/17/2017 2:30 PM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Kyle Poole",
+          "company": "Instrument",
+          "twitter": "kylpo",
+          "github": "yokelpole",
+          "bio":"Kyle Poole and Thomas Bruketta will co-present this talk. This dynamic duo has been crafting React Native applications at Instrument (here in Portland) over the last year for global clients. Both developers are contributors to the React Native open source community and Kyle Poole has created a collection of React Native primitives called Constelation that are a part of our team’s daily workflow "
+        },
+        {
+          "name": "Thomas Brunketta",
+          "company": "Instrument",
+          "twitter": "SirTeebs",
+          "bio":"Kyle Poole and Thomas Bruketta will co-present this talk. This dynamic duo has been crafting React Native applications at Instrument (here in Portland) over the last year for global clients. Both developers are contributors to the React Native open source community and Kyle Poole has created a collection of React Native primitives called Constelation that are a part of our team’s daily workflow "
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Javier Cuevas",
+      "speaker":"Javier Cuevas",
       "image":"javier",
-      "twitter":"javier_dev",
-      "company":"Gudog",
-      "bio":"Co-founder / CTO at @Gudog. Formerly CEO at @Diacode. College dropout. Interests: Ruby, Elixir, React Native, Education, FinTech, Marketplaces.",
       "title":"Rewriting a Large Hybrid App with React Native",
       "description":"In this talk we’ll share Gudog’s experience on rewriting our large Ionic / Cordova hybrid mobile app with React Native (using Ignite, redux, redux-saga & normalizr).",
       "time":"7/17/2017 4:00 PM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Javier Cuevas",
+          "twitter":"javier_dev",
+          "github": "javiercr",
+          "company":"Gudog",
+          "bio":"Co-founder / CTO at @Gudog. Formerly CEO at @Diacode. College dropout. Interests: Ruby, Elixir, React Native, Education, FinTech, Marketplaces."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Chris Ball",
+      "speaker":"Chris Ball",
       "image":"chris",
-      "twitter":"cball_",
-      "company":"Echobind",
-      "bio":"Managing Partner at @echobind. Maker. Cycling & camping to counter-balance business & code.",
       "title":"From Idea to App Store: A Guide to Shipping ReactNative Apps",
       "description":"We’ll walk through everything involved in taking an app from initial concept all the way to submitting an iOS and Android app to the App Stores.",
       "time":"7/17/2017 4:30 PM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Chris Ball",
+          "twitter":"cball_",
+          "github": "cball",
+          "company":"Echobind",
+          "bio":"Managing Partner at @echobind. Maker. Cycling & camping to counter-balance business & code."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Peggy Rayzis",
+      "speaker":"Peggy Rayzis",
       "image":"peggy",
-      "twitter":"peggyrayzis",
-      "company":"Major League Soccer",
-      "bio":"Exploring the world through code, travel, and music ✨ Software Engineer @MLS.",
       "title":"Breaking Down React Native Bridging",
       "description":"Crossing the bridge between native and JavaScript code can seem daunting, but it doesn’t have to be! This talk will simplify the process of bridging native modules & components by breaking down common patterns found in bridging implementations for iOS & Android.",
       "time":"7/18/2017 9:00 AM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Peggy Rayzis",
+          "twitter":"peggyrayzis",
+          "github": "peggyrayzis",
+          "company":"Major League Soccer",
+          "bio":"Exploring the world through code, travel, and music ✨ Software Engineer @MLS."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Eric Baer",
+      "speaker":"Eric Baer",
       "image":"eric",
-      "twitter":"ebaerbaerbaer",
-      "company":"Formidable Labs",
-      "bio":"Eric has been developing software for over 10 years ranging from embedded systems in C++ to high traffic APIs in Java and JavaScript. For the past five years Eric has developed a deep specialization in JavaScript and the associated ecosystem. In his current role, Eric is a lead engineer at Formidable in Seattle where he is driving large projects, and writing software around Babel, GraphQL, and i18n.",
       "title":"From RPC to GraphQL: APIs from Past to Present",
       "description":"",
       "time":"7/18/2017 9:30 AM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Eric Baer",
+          "twitter":"ebaerbaerbaer",
+          "github": "baer",
+          "company":"Formidable Labs",
+          "bio":"Eric has been developing software for over 10 years ranging from embedded systems in C++ to high traffic APIs in Java and JavaScript. For the past five years Eric has developed a deep specialization in JavaScript and the associated ecosystem. In his current role, Eric is a lead engineer at Formidable in Seattle where he is driving large projects, and writing software around Babel, GraphQL, and i18n."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Parashuram Narasimhan",
+      "speaker":"Parashuram Narasimhan",
       "image":"parashuram",
-      "twitter":"nparashuram",
-      "company":"Microsoft",
-      "bio":"Parashuram is a Senior Program Manager with Microsoft Open Technologies Inc and works on many interesting open source projects including Apache Cordova and Chromium. He is a front end developer passionate about web performance and like to talk about performance practices at conferences. He is also a committer and a member of the Project Management Committee of Apache Cordova.",
       "title":"From Zero to DevOps",
       "description":"React Native brought the web’s enviable development patterns to mobile, without needing to sacrifice native UI. Code Push for React Native brings web like release agility to mobile apps by enabling developers to update apps instantly. This talk will cover the next iteration of Code Push and how it fits into a complete suite of DevOps services built for called Mobile Center, built for React Native. We will look at the end to end workflow - from a single commit on github triggering continuous builds and tests, to the final, signed app distributed to testers, clients or end users. From monitoring services like JavaScript enabled crashes to understanding user behavior with analytics, we will look at ways to get better mobile apps to your users. We will look at the internals of Mobile Center to use with your existing toolchain, other services that are planned as a part of the suite, and integration with popular community tools and services.",
       "time":"7/18/2017 10:30 AM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Parashuram Narasimhan",
+          "twitter":"nparashuram",
+          "github": "axemclion",
+          "company":"Microsoft",
+          "bio":"Parashuram is a Senior Program Manager with Microsoft Open Technologies Inc and works on many interesting open source projects including Apache Cordova and Chromium. He is a front end developer passionate about web performance and like to talk about performance practices at conferences. He is also a committer and a member of the Project Management Committee of Apache Cordova."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Leland Richardson",
+      "speaker":"Leland Richardson",
       "image":"leland",
-      "twitter":"intelligibabble",
-      "company":"Airbnb",
-      "bio":"Leland is a Software Engineer at Airbnb. He likes learning, discussing, and diving into challenges.",
       "title":"React as a Platform: A path towards a truly cross-platform UI",
       "description":"React provides an abstraction between the description of a UI and the details of how it's rendered on a given platform. The problem is that <div> and <span> are a hidden dependency on react-dom, and similarly, React Native's <View> is an explicit dependency on Native, making both not quite as \"cross-platform\" as we want them to be. Learn how we as a community can get around these issues, and what we can unlock by doing so.",
       "time":"7/18/2017 11:00 AM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Leland Richardson",
+          "twitter":"intelligibabble",
+          "github": "lelandrichardson",
+          "company":"Airbnb",
+          "bio":"Leland is a Software Engineer at Airbnb. He likes learning, discussing, and diving into challenges."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Kevin Old",
+      "speaker":"Kevin Old",
       "image":"kevin",
-      "twitter":"kevinold",
-      "company":"LifeWay Christian Resources",
-      "bio":"Kevin is a Full-stack, Front-end focused Software Engineer, husband and amateur photographer living in Nashville, TN.",
       "title":"Building Serverless Backends with AWS Lambda for React Native Apps",
       "description":"This talk will explore a Serverless Architecture and how it can can aid any React Native developer in building scalable backends for their applications. Our provider of choice will be Amazon’s AWS ecosystem and AWS Lambda, DynamoDB, Cognito and API Gateway will be among the resources covered.",
       "time":"7/18/2017 11:30 AM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Kevin Old",
+          "twitter":"kevinold",
+          "github": "kevinold",
+          "company":"LifeWay Christian Resources",
+          "bio":"Kevin is a Full-stack, Front-end focused Software Engineer, husband and amateur photographer living in Nashville, TN."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Panelists",
+      "speaker":"Panelists",
       "image":"",
-      "twitter":["syke","mateobarraza","jevakallio","sugargreenbean","sanketsahu","drnugent"],
-      "company":"",
-      "bio":"Matt Hargett\nMateo Barraza\nJani Eväkallio\nJennifer Van\nSanket Sahu\nDave Nugent",
       "title":"Panel",
       "description":"",
       "time":"7/18/2017 1:30 PM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Matt Hargett",
+          "twitter": "syke",
+          "github": "matthargett",
+          "company": "Blue Jeans",
+          "bio": "React Native contributer."
+        },
+        {
+          "name": "Mateo Barraza",
+          "twitter": "mateobarraza",
+          "bio": "A technologist, entrepreneur, someone who is too curious to stay put.",
+          "company": "TalkRecursive Inc."
+        },
+        {
+          "name": "Jani Eväkallio",
+          "twitter": "jevakallio",
+          "github": "jevakallio",
+          "bio": "Lead Engineer at Formidable Labs",
+          "company": "Formidable Labs"
+        },
+        {
+          "name": "Sanket Sahu",
+          "twitter": "sanketsahu",
+          "github": "sanketsahusoft",
+          "bio": "Co-created NativeBase.io & Founder of GeekyAnts.com",
+          "company": "NativeBase"
+        },
+        {
+          "name": "Jennifer Van",
+          "twitter": "sugargreenbean",
+          "github": "sugargreenbean",
+          "company": "Capital One",
+          "bio": "Rugby player, bartender, bus driver, and artist turned web developer"
+        },
+        {
+          "name": "Dave Nugent",
+          "twitter": "drnugent",
+          "github": "drnugent",
+          "company": "Qlik",
+          "bio": "Dave is a JavaScript developer and advocate. Previously at NASA, he lends his talents to Qlik Branch and Qlik Playground, organises the San Francisco JavaScript Meetup and curates the Forward Web Summit. His expertise? Intuitive enterprise analytics and visualisations in JavaScript. His goal? Building delightful developer experiences with Qlik technology. His love? The open web. He combines all three in his current role as Developer Relations Engineer at Qlik where he gets to bring together JavaScript, technology and people. When you meet him, be sure to tell him about any good local doughnut shops."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Harry Tormey",
+      "speaker":"Harry Tormey",
       "image":"harry",
-      "twitter":"htormey",
-      "company":"LaunchDrawer",
-      "bio":"Software engineer with a background in media. Loves foreign cinema, random music and indie games.",
       "title":"When to Go Native Over Javascript",
       "description":"React Native is great for writing cross platform apps. Certain use-cases, however, still require native code. Together we will look at how to evaluate when native code is the better choice. I’ll cover strategies for dealing with performance issues and how to handle background tasks like geolocation.",
       "time":"7/18/2017 2:00 PM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Harry Tormey",
+          "twitter":"htormey",
+          "github": "hgale",
+          "company":"LaunchDrawer",
+          "bio":"Software engineer with a background in media. Loves foreign cinema, random music and indie games."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Alex Kotliarskyi",
+      "speaker":"Alex Kotliarskyi",
       "image":"alex",
-      "twitter":"alex_frantic",
-      "company":"Facebook",
-      "bio":"Helping build amazing experiences at Oculus. Worked at Facebook on React Native core & devtools.",
       "title":"Building Stellar User Experiences with React Native",
       "description":"As React Native developers we take so much pride in how fast it takes us to build something functional on mobile. However, the development speed is only half of the story. In this talk Alex, a former React Native team member, will share his insight about building amazing user experiences, and how attention to little design details can fundamentally change the quality of your app.",
       "time":"7/18/2017 2:30 PM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Alex Kotliarskyi",
+          "twitter":"alex_frantic",
+          "github": "frantic",
+          "company":"Facebook",
+          "bio":"Helping build amazing experiences at Oculus. Worked at Facebook on React Native core & devtools."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Doug Lowder",
+      "speaker":"Doug Lowder",
       "image":"doug",
-      "twitter":"douglowder",
-      "company":"SalesForce",
-      "bio":"Mobile software developer, and Irish traditional musician.",
       "title":"React Native on the Apple TV Platform",
       "description":"Support for the Apple TV platform has recently been added to React Native. This talk will cover differences between the Apple TV and other platforms, details on the changes that were made to React Native core code to support Apple TV, and examples of React Native applications running on Apple TV.",
       "time":"7/18/2017 4:00 PM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Doug Lowder",
+          "twitter":"douglowder",
+          "company":"SalesForce",
+          "bio":"Mobile software developer, and Irish traditional musician."
+        }
+      ]
     },
     {
       "type":"talk",
-      "name":"Ken Wheeler",
+      "speaker":"Ken Wheeler",
       "image":"ken",
-      "twitter":"ken_wheeler",
-      "company":"Formidable Labs",
-      "bio":"Ken Wheeler is the Director of Open Source at Formidable and the author of open source libraries such as Slick Carousel, Spectacle, webpack-dashboard and react-music.",
       "title":"React Native with Electronics",
       "description":"In this talk I will explore how using React Native with Robotics makes prototyping a breeze and enables mobile control of almost anything",
       "time":"7/18/2017 4:30 PM",
-      "duration":"30"
+      "duration":"30",
+      "speakerInfo": [
+        {
+          "name": "Ken Wheeler",
+          "twitter":"ken_wheeler",
+          "github": "kenwheeler",
+          "company":"Formidable Labs",
+          "bio":"Ken Wheeler is the Director of Open Source at Formidable and the author of open source libraries such as Slick Carousel, Spectacle, webpack-dashboard and react-music."
+        }
+      ]
     },
     {
       "type":"coffee",


### PR DESCRIPTION
Trello: https://trello.com/c/iQKEQ7xB/36-social-links-for-multiple-speakers-are-broken

Puts speaker info into an array, and renders each individually on the talk detail screen. I also added each speaker's github name to make those links actually work. 