### PR TITLE
Define flex for directions & address to prevent pushing icon off screen

### DIFF
--- a/App/Containers/LocationScreen.js
+++ b/App/Containers/LocationScreen.js
@@ -163,7 +163,7 @@ class LocationScreen extends React.Component {
             <View style={styles.mapActions}>
               <TouchableOpacity onPress={() => this.openMaps()}>
                 <View style={styles.getDirections}>
-                  <View>
+                  <View style={styles.addressContainer}>
                     <Text style={styles.venueName}>
                       The Armory
                     </Text>

--- a/App/Containers/Styles/LocationScreenStyle.js
+++ b/App/Containers/Styles/LocationScreenStyle.js
@@ -64,8 +64,12 @@ export default StyleSheet.create({
     letterSpacing: 0,
     color: Colors.lightText
   },
+  addressContainer: {
+    flex: 4
+  },
   directionsIcon: {
-    alignItems: 'center'
+    alignItems: 'center',
+    flex: 1
   },
   directionsLabel: {
     fontFamily: 'Avenir-Medium',


### PR DESCRIPTION
![image uploaded from ios 5](https://cloud.githubusercontent.com/assets/10098988/26791004/6052125a-49db-11e7-84fe-70ad9e199cd8.jpg)
Was happening on my iPhone 6.
Couldn't reproduce on simulator.
Added flex properties to views to prevent overflow.