### PR TITLE
Improve scroll logic when toggle rides is tapped

### DIFF
--- a/App/Containers/LocationScreen.js
+++ b/App/Containers/LocationScreen.js
@@ -88,7 +88,10 @@ class LocationScreen extends React.Component {
   }
 
   toggleRides = () => {
-    this.refs.scrolly.scrollTo({x: 0, y: 180, animated: true})
+    const { showRideOptions, scrollY } = this.state
+    if (!showRideOptions && scrollY._value < 200) {
+      this.refs.scrolly.scrollTo({x: 0, y: 200, animated: true})
+    }
     this.setState({showRideOptions: !this.state.showRideOptions})
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4510,18 +4510,18 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@~15.5.7:
-  version "15.5.8"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
-  dependencies:
-    fbjs "^0.8.9"
-
-prop-types@^15.5.10:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
+
+prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
 
 prr@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Only scroll to show ride request buttons if they aren't visible yet and we haven't scrolled far enough down.