### PR TITLE
Fix device software button bar transparency on Android

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,7 +3,6 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
-         <item name="android:windowIsTranslucent">true</item>
          <item name="android:windowBackground">@mipmap/splash</item>
     </style>
 


### PR DESCRIPTION
Fixes #101.

I am not sure if this has any side effects. The `android:windowIsTranslucent` was originally introduced by @GantMan as part of the splash screen in https://github.com/infinitered/ChainReactApp/commit/0d7d481eb3533c2379d38f4a4fa367c785815856, and I can confirm the splash screen works on my S8 as well as a Android stock emulator even without this configuration.