### PR TITLE
remove landscape for android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,9 +50,10 @@
     </service>
 
     <activity
+      android:screenOrientation="portrait"
+      android:configChanges="orientation|keyboardHidden"
       android:name=".MainActivity"
       android:label="@string/app_name"
-      android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
       android:windowSoftInputMode="adjustResize">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Since we never got designs for Landscape, we turned it off in iOS but apparently left it on in Android.  

This code turns it off in Android
Fixes #110 and #109

Eventual fix:  Add a question/script in `ignite new` which asks if you ever intend to support landscape.  If your answer is "no" just turn it off!!!