### PR TITLE
Event/Break Detail click issue

### DIFF
--- a/App/Containers/BreakDetailScreen.js
+++ b/App/Containers/BreakDetailScreen.js
@@ -32,6 +32,8 @@ class BreakDetail extends React.Component {
   }
 
   goBack = () => {
+    const {params: {reset}} = this.props.navigation.state
+    typeof reset === 'function' && reset()
     this.props.navigation.dispatch(NavigationActions.back())
   }
 

--- a/App/Containers/ScheduleScreen.js
+++ b/App/Containers/ScheduleScreen.js
@@ -44,7 +44,7 @@ class ScheduleScreen extends Component {
     const isCurrentDay = isActiveCurrentDay(currentTime, activeDay)
     const appState = AppState.currentState
 
-    this.state = {eventsByDay, data, isCurrentDay, activeDay, appState}
+    this.state = {eventsByDay, data, isCurrentDay, activeDay, appState, navigatingToDetail: false}
   }
 
   static navigationOptions = {
@@ -77,12 +77,16 @@ class ScheduleScreen extends Component {
   }
 
   onEventPress = (item) => {
+    if (this.state.navigatingToDetail) return
+
     const { navigation, setSelectedEvent } = this.props
     setSelectedEvent(item)
 
+    const reset = () => this.setState({navigatingToDetail: false})
     item.type === 'talk'
-      ? navigation.navigate('TalkDetail')
-      : navigation.navigate('BreakDetail')
+      ? navigation.navigate('TalkDetail', {reset})
+      : navigation.navigate('BreakDetail', {reset})
+    this.setState({navigatingToDetail: true})
   }
 
   componentDidMount () {

--- a/App/Containers/TalkDetailScreen.js
+++ b/App/Containers/TalkDetailScreen.js
@@ -27,6 +27,8 @@ class TalkDetail extends React.Component {
   }
 
   goBack = () => {
+    const {params: {reset}} = this.props.navigation.state
+    typeof reset === 'function' && reset()
     this.props.navigation.dispatch(NavigationActions.back())
   }
 


### PR DESCRIPTION
Hi,
Thanks for s great conference. I really enjoyed it. Also really enjoyed the app and I used it all the time. I found a navigation issue though. If you double (or more) click an event (or break) and manage to get the extra clicks in before the detail screen is visible you get a number of identical detail screens stacked on top of each other. This is actually really easy to reproduce. Especially in the simulator.
Anyway I think this PR fixes the problem. It just doesn't feel particularly clean and it feels there must be a better way. I understand the conference is over and the app is probably dead from here on but for my education it would be interesting to hear your thoughts.
Thanks again,
/Daniel